### PR TITLE
Update spitftbitmap.ino - read16/read32 should use a reference to the File object

### DIFF
--- a/examples/spitftbitmap/spitftbitmap.ino
+++ b/examples/spitftbitmap/spitftbitmap.ino
@@ -179,14 +179,14 @@ void bmpDraw(char *filename, uint8_t x, uint8_t y) {
 // BMP data is stored little-endian, Arduino is little-endian too.
 // May need to reverse subscript order if porting elsewhere.
 
-uint16_t read16(File f) {
+uint16_t read16(File & f) {
   uint16_t result;
   ((uint8_t *)&result)[0] = f.read(); // LSB
   ((uint8_t *)&result)[1] = f.read(); // MSB
   return result;
 }
 
-uint32_t read32(File f) {
+uint32_t read32(File & f) {
   uint32_t result;
   ((uint8_t *)&result)[0] = f.read(); // LSB
   ((uint8_t *)&result)[1] = f.read();


### PR DESCRIPTION
read16 and read32 should use a reference to the File object rather than the object itself.  On Yun the File/FileIO destructor causes the file to be closed when read16/read32 return so future read16/32 calls fail to read any data.  Using a reference prevents the destructor from being called so the file stays open as expected.
