### PR TITLE
Use D/C = pin9 and RST = pin8 to match Adafruit_SS7735R examples

### DIFF
--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -29,8 +29,8 @@
 #define _miso 12
 #define _mosi 11
 #define _cs 10
-#define _rst 9
-#define _dc 8
+#define _dc 9
+#define _rst 8
 
 // Using software SPI is really not suggested, its incredibly slow
 //Adafruit_ILI9340 tft = Adafruit_ILI9340(_cs, _dc, _mosi, _sclk, _rst, _miso);

--- a/examples/spitftbitmap/spitftbitmap.ino
+++ b/examples/spitftbitmap/spitftbitmap.ino
@@ -28,8 +28,8 @@
 // Hardware SPI pins are specific to the Arduino board type and
 // cannot be remapped to alternate pins.  For Arduino Uno,
 // Duemilanove, etc., pin 11 = MOSI, pin 12 = MISO, pin 13 = SCK.
-#define TFT_RST 9
-#define TFT_DC 8
+#define TFT_RST 8
+#define TFT_DC 9
 #define TFT_CS 10
 #define SD_CS 4
 


### PR DESCRIPTION
This tiny & trivial change to the examples makes the 2.2 inch TFT connections the same as the 1.8 inch TFT product.  Consistency might be nice?  Easier to change now, before a tutorial is written on the Adafruit Learning System for this newer 2.2 inch TFT.

Here's the example code for the 1.8 inch TFT.

https://github.com/adafruit/Adafruit-ST7735-Library/blob/master/examples/graphicstest_highspeed/graphicstest_highspeed.pde#L22
