### PR TITLE
XOR compressed fonts...

### DIFF
--- a/Adafruit_ILI9340.cpp
+++ b/Adafruit_ILI9340.cpp
@@ -657,9 +657,9 @@ uint8_t Adafruit_ILI9340::spiread(void) {
  */
 
 #if ARDUINO < 100
-size_t _ILI9340::write(uint8_t c) {
+size_t Adafruit_ILI9340::write(uint8_t c) {
 #else
-void _ILI9340::write(uint8_t c) {
+void Adafruit_ILI9340::write(uint8_t c) {
 #endif
 	int charWidth;
   if (c == '\n') {
@@ -686,7 +686,7 @@ void _ILI9340::write(uint8_t c) {
 
 // draw a character
 #include "glcdfont.c"
-void _ILI9340::drawChar(int16_t x, int16_t y, unsigned char c,
+void Adafruit_ILI9340::drawChar(int16_t x, int16_t y, unsigned char c,
 			    uint16_t color, uint16_t bg, uint8_t size) {
 
   if((x >= _width)            || // Clip right

--- a/Adafruit_ILI9340.h
+++ b/Adafruit_ILI9340.h
@@ -126,6 +126,7 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
   Adafruit_ILI9340(uint8_t CS, uint8_t RS, uint8_t MOSI, uint8_t SCLK,
 		   uint8_t RST, uint8_t MISO);
   Adafruit_ILI9340(uint8_t CS, uint8_t RS, uint8_t RST);
+	bool m_tiny;
 
   void     begin(void),
            setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1),
@@ -136,6 +137,8 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
            drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
            fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
              uint16_t color),
+           drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h,
+	     uint16_t color, uint16_t bgcolor),
            setRotation(uint8_t r),
            invertDisplay(boolean i);
   uint16_t Color565(uint8_t r, uint8_t g, uint8_t b);
@@ -155,6 +158,13 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
     commandList(uint8_t *addr);
   uint8_t  spiread(void);
 
+#if ARDUINO < 100
+  virtual size_t write(uint8_t);
+#else
+  virtual void   write(uint8_t);
+#endif
+  void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
+      uint16_t bg, uint8_t size);
  private:
   uint8_t  tabcolor;
 

--- a/Adafruit_ILI9340.h
+++ b/Adafruit_ILI9340.h
@@ -126,7 +126,7 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
   Adafruit_ILI9340(uint8_t CS, uint8_t RS, uint8_t MOSI, uint8_t SCLK,
 		   uint8_t RST, uint8_t MISO);
   Adafruit_ILI9340(uint8_t CS, uint8_t RS, uint8_t RST);
-	bool m_tiny;
+	bool m_proportional;
 
   void     begin(void),
            setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1),

--- a/Adafruit_ILI9340.h
+++ b/Adafruit_ILI9340.h
@@ -137,7 +137,7 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
            drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
            fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
              uint16_t color),
-           drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h,
+           drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t wReal, int16_t h,
 	     uint16_t color, uint16_t bgcolor),
            setRotation(uint8_t r),
            invertDisplay(boolean i);


### PR DESCRIPTION
Hello,

this is a "POC" of simple, but effective font compression already implemented on of my project; please check also original repository (https://github.com/eltomjan/Adafruit_ILI9340) - do not know how to propagate latest changes to this request.
You can see results on my https://github.com/eltomjan/ETEhomeTools or test on Windows port in https://github.com/eltomjan/ETEhomeTools/tree/master/ArduinoSimulator, there is also Win build EXE https://github.com/eltomjan/ETEhomeTools/raw/master/ArduinoSimulator/ArduinoSimulatorEXE.zip of this demo.
I found fonts I am using are a bit bigger if XORed by both axes, but it should be quite random, so I left optional row xor logic in place.
I have changed also GFX, etc. 4 my project - I am printing same way like clear screen, so there is way better print speed (as SPI data are significantly reduced).
There is also option to print font as proportional, also write return pixel width instead of char's no 4 proportional.

Older version run on Pololu - A-Star 32U4 Micro, but latest changes were made & tested in simulator and then merged to original version.
If you prefer simple Arduino cage test, there is also a Cage.cpp in my Simulator, that should work in Arduino directly (if few related files from Simulator folder are included).

In case you want to create or import different fonts, there is also a cmd tool fntXorPacker.cpp (fntXorPacker was a main originally, but the renamed as I placed test parameters 2 different main calling that function).
It has GLCD, ASCII and "own" XORed fonts import options (GLCD & XORed are read as = {data} array from include file) , export only as XORed, but with huge comment showing whole proces, etc. (ASCII original, XORed, row bitmap bit 4 each row, column bitmap in case there are any data in the row, ASCII bytes again with dots instead of zeros and hexa non-zero data in output for particular row bytes).
Then ASCII part (even full comment content from XORed) could be used to (edit?) & read font again.

I am open to any questions/comments or improvements ;-)
Fonts could be switched, but I am using only one size for each font.

BR,
El Tom
P.S. For testing GLCD font import this project used https://github.com/andygock/glcd (planning to propose XORed export there too).