### PR TITLE
Added Feather M0 support

### DIFF
--- a/Adafruit_ILI9340.cpp
+++ b/Adafruit_ILI9340.cpp
@@ -36,7 +36,7 @@
   #define SET_BIT(port, bitMask) *(port) |= (bitMask)
   #define CLEAR_BIT(port, bitMask) *(port) &= ~(bitMask)
 #endif
-#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266)
+#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266) || defined(__SAMD21G18A__) 
   #define USE_SPI_LIBRARY
   #define SET_BIT(port, bitMask) digitalWrite(*(port), HIGH);
   #define CLEAR_BIT(port, bitMask) digitalWrite(*(port), LOW);
@@ -171,7 +171,7 @@ void Adafruit_ILI9340::begin(void) {
   csport    = digitalPinToPort(_cs);
   dcport    = digitalPinToPort(_dc);
 #endif
-#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266)
+#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266) || defined(__SAMD21G18A__) 
   mosiport = &_mosi;
   clkport = &_sclk;
   rsport = &_rst;

--- a/Adafruit_ILI9340.h
+++ b/Adafruit_ILI9340.h
@@ -171,7 +171,7 @@ class Adafruit_ILI9340 : public Adafruit_GFX {
   uint32_t  _cs, _dc, _rst, _mosi, _miso, _sclk,
             mosipinmask, clkpinmask, cspinmask, dcpinmask;
 #endif //  #if defined(__SAM3X8E__)
-#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266)
+#if (defined(__arm__) && defined(CORE_TEENSY)) || defined(ESP8266) || defined(__SAMD21G18A__)
   volatile uint8_t *mosiport, *clkport, *dcport, *rsport, *csport;
   uint8_t  _cs, _dc, _rst, _mosi, _miso, _sclk,
            mosipinmask, clkpinmask, cspinmask, dcpinmask;


### PR DESCRIPTION
Made changes to two files adding the preprocessor directive of || defined(__SAMD21G18A__) along with the __arm__ directive.  This fixes all of the out of scope errors when compiling this library on a Feather M0 wifi.  Feel free to edit or suggest changes as needed.


